### PR TITLE
feat: add authentication keys for package managers and api access

### DIFF
--- a/lib/hexagon/accounts.ex
+++ b/lib/hexagon/accounts.ex
@@ -4,8 +4,8 @@ defmodule Hexagon.Accounts do
   """
 
   import Ecto.Query, warn: false
-  alias Hexagon.Repo
 
+  alias Hexagon.Repo
   alias Hexagon.Accounts.{User, UserToken, UserNotifier}
 
   ## Database getters

--- a/lib/hexagon/accounts/user_token.ex
+++ b/lib/hexagon/accounts/user_token.ex
@@ -16,7 +16,7 @@ defmodule Hexagon.Accounts.UserToken do
   @session_validity_in_days 60
 
   schema "users_tokens" do
-    field :token, :binary
+    field :token, :binary, redact: true
     field :context, :string
     field :sent_to, :string
     belongs_to :user, Hexagon.Accounts.User

--- a/lib/hexagon/authentication.ex
+++ b/lib/hexagon/authentication.ex
@@ -1,0 +1,114 @@
+defmodule Hexagon.Authentication do
+  @moduledoc """
+  The Authentication context. This refers to API tokens and how package
+  managers authenticate with the system. If you are looking at how users
+  are authenticated with the web UI, see the `Hexagon.Accounts` context.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Hexagon.Repo
+  alias Hexagon.Accounts.User
+  alias Hexagon.Authentication.Key
+
+  @doc """
+  Lists keys for a given subject.
+
+  ## Examples
+
+      iex> list_keys(%User{})
+      [%Key{}, ...]
+
+  """
+  def list_keys(%User{id: user_id}) do
+    Key
+    |> where([key], key.user_id == ^user_id)
+    |> Repo.all()
+  end
+
+  @doc """
+  Gets an authentication key via the token string.
+
+  ## Examples
+
+      iex> get_key("exists")
+      %Key{}
+
+      iex> get_key("nil")
+      nil
+
+  """
+  def get_key(token) do
+    Plug.Crypto.secure_compare("", "")
+
+    case Key.verify_query(token) do
+      {:ok, query} -> Repo.one(query)
+      :error -> nil
+    end
+  end
+
+  @doc """
+  Creates a new authentication key for the subject. This is a shortcut
+  for `create_key/1`. See that function for more details.
+  """
+  def create_key(%User{id: user_id}, attrs) do
+    attrs
+    |> Map.put("user_id", user_id)
+    |> create_key()
+  end
+
+  @doc """
+  Creates a new authentication key for the subject. Note this returns a three
+  tuple on success with the usable token so the user can store it.
+
+  ## Examples
+
+      iex> create_key(%{name: "test", user_id: 123})
+      {:ok, %Hexagon.Authentication.Key{}, "abc123"}
+
+      iex> create_key(%{name: nil})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_key(attrs) do
+    {usable_token, hashed_token} = Key.build_hashed_token()
+    changeset = Key.changeset(%Key{}, Map.put(attrs, "token", hashed_token))
+
+    case Repo.insert(changeset) do
+      {:ok, key} -> {:ok, key, usable_token}
+      res -> res
+    end
+  end
+
+  @doc """
+  Updates an existing key. Note, you will only be able to update the
+  name field.
+
+  ## Examples
+
+      iex> update_key(%Key{}, %{name: "testing"})
+      {:ok, %Key{}}
+
+      iex> update_key(%Key{}, %{name: nil})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_key(key, attrs) do
+    key
+    |> Key.update_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for changing a key.
+
+  ## Examples
+
+      iex> change_key(key)
+      %Ecto.Changeset{data: %Key{}}
+
+  """
+  def change_key(record, attrs \\ %{})
+  def change_key(nil, attrs), do: Key.changeset(%Key{}, attrs)
+  def change_key(key, attrs), do: Key.update_changeset(key, attrs)
+end

--- a/lib/hexagon/authentication/key.ex
+++ b/lib/hexagon/authentication/key.ex
@@ -1,0 +1,86 @@
+defmodule Hexagon.Authentication.Key do
+  use Ecto.Schema
+
+  import Ecto.{Changeset, Query}
+
+  @hash_algorithm :sha256
+  @rand_size 64
+
+  schema "authentication_keys" do
+    field :name, :string
+    field :token, :binary, redact: true
+
+    belongs_to :user, Hexagon.Accounts.User
+
+    timestamps()
+  end
+
+  @doc """
+  Creates an `Ecto.Changeset` for `#{__MODULE__}`. This requires you to specify a
+  hashed token when you create a record. To do this, see the
+  `build_hashed_token/0` method.
+  """
+  def changeset(token, attrs) do
+    token
+    |> cast(attrs, [:name, :user_id, :token])
+    |> validate_name()
+    |> validate_required([:user_id, :token])
+  end
+
+  @doc """
+  Creates an `Ecto.Changeset` for updating an already existing `#{__MODULE__}`.
+  """
+  def update_changeset(token, attrs) do
+    token
+    |> cast(attrs, [:name])
+    |> validate_name()
+  end
+
+  defp validate_name(changeset) do
+    changeset
+    |> validate_required([:name])
+    |> validate_length(:name, max: 255)
+  end
+
+  @doc """
+  Builds a token and a hashed version of that token.
+
+  The non-hashed token is sent to the end user to be stored how they want. The
+  hashed part is stored in the database. The original token cannot be reconstructed,
+  which means anyone with read-only access to the database cannot directly use
+  the token in the application to gain access.
+  """
+  @spec build_hashed_token() :: {binary(), binary()}
+  def build_hashed_token() do
+    token = :crypto.strong_rand_bytes(@rand_size)
+    hashed_token = :crypto.hash(@hash_algorithm, token)
+
+    {Base.url_encode64(token, padding: false), hashed_token}
+  end
+
+  @doc """
+  Checks if the token is valid and returns its underlying lookup query.
+
+  The query returns the `#{__MODULE__}` found by the token, if any.
+
+  The given token is valid if it matches its hashed counterpart in the
+  database.
+  """
+  def verify_query(token) do
+    case Base.url_decode64(token, padding: false) do
+      {:ok, decoded_token} ->
+        hashed_token = :crypto.hash(@hash_algorithm, decoded_token)
+
+        query =
+          from key in __MODULE__,
+            join: user in assoc(key, :user),
+            where: key.token == ^hashed_token,
+            preload: [user: user]
+
+        {:ok, query}
+
+      :error ->
+        :error
+    end
+  end
+end

--- a/lib/hexagon_web/plugs/api_authentication.ex
+++ b/lib/hexagon_web/plugs/api_authentication.ex
@@ -1,0 +1,33 @@
+defmodule HexagonWeb.ApiAuthenticationPlug do
+  @moduledoc """
+  Attempts to authenticate via a `Hexagon.Authentication.Key` token in the header.
+  """
+
+  import Plug.Conn
+
+  alias Hexagon.Authentication
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    token =
+      case get_req_header(conn, "authorization") do
+        [token | _] -> token
+        [] -> nil
+      end
+
+    if key = Authentication.get_key(token) do
+      conn
+      |> assign(:current_key, key)
+      |> assign(:current_user, key.user)
+    else
+      conn
+      |> send_resp(401, "Unauthenticated")
+      |> halt()
+    end
+  end
+end

--- a/lib/hexagon_web/router.ex
+++ b/lib/hexagon_web/router.ex
@@ -76,6 +76,7 @@ defmodule HexagonWeb.Router do
     pipe_through [:browser, :require_authenticated_user]
 
     get "/users/settings", UserSettingsController, :edit
+    post "/users/settings", UserSettingsController, :create
     put "/users/settings", UserSettingsController, :update
     get "/users/settings/confirm_email/:token", UserSettingsController, :confirm_email
   end

--- a/lib/hexagon_web/templates/user_settings/edit.html.heex
+++ b/lib/hexagon_web/templates/user_settings/edit.html.heex
@@ -59,7 +59,7 @@
       <div class="shadow sm:rounded-md sm:overflow-hidden">
         <div class="bg-white py-6 px-4 sm:p-6">
           <div>
-            <h2 id="email-heading" class="text-lg leading-6 font-medium text-gray-900">
+            <h2 id="password-heading" class="text-lg leading-6 font-medium text-gray-900">
               Change Password
             </h2>
             <%= if @password_changeset.action do %>
@@ -119,5 +119,77 @@
         </div>
       </div>
     </.form>
+  </section>
+
+  <section aria-labelledby="authentication-heading">
+    <div class="shadow sm:rounded-md sm:overflow-hidden">
+      <div class="bg-white">
+        <div class="pt-6 px-4 sm:pt-6 sm:px-6">
+          <h2 id="authentication-heading" class="text-lg leading-6 font-medium text-gray-900">
+            Authentication Keys
+          </h2>
+          <p class="mt-1 text-sm text-gray-500">
+            API and repository access authentication tokens.
+          </p>
+        </div>
+
+        <table class="mt-6 min-w-full divide-y divide-gray-300">
+          <thead class="bg-gray-50">
+            <tr>
+              <th
+                scope="col"
+                class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 lg:pl-8"
+              >
+                Name
+              </th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                Created At
+              </th>
+              <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6 lg:pr-8">
+                <span class="sr-only">Delete</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <%= for key <- @keys do %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 lg:pl-8">
+                  <%= key.name %>
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  <%= key.inserted_at %>
+                </td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8">
+                  <a href="#" class="text-indigo-600 hover:text-indigo-900">
+                    Delete<span class="sr-only">, <%= key.name %></span>
+                  </a>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <.form let={f} for={@key_changeset} action={Routes.user_settings_path(@conn, :update)}>
+        <%= hidden_input(f, :action, name: "action", value: "create_key") %>
+
+        <div class="flex px-4 py-3 bg-gray-50 justify-between items-center sm:px-6">
+          <div class="flex items-center space-x-4">
+            <%= label(f, :name, class: "text-sm font-medium text-gray-700") %>
+            <%= text_input(f, :name,
+              required: true,
+              class:
+                "border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-gray-900 focus:border-gray-900 sm:text-sm"
+            ) %>
+            <%= error_tag(f, :name) %>
+          </div>
+
+          <%= submit("Create Key",
+            class:
+              "bg-gray-800 border border-transparent rounded-md shadow-sm py-2 px-4 inline-flex justify-center text-sm font-medium text-white hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900"
+          ) %>
+        </div>
+      </.form>
+    </div>
   </section>
 </div>

--- a/priv/repo/migrations/20220828030827_create_authentication_tables.exs
+++ b/priv/repo/migrations/20220828030827_create_authentication_tables.exs
@@ -1,0 +1,16 @@
+defmodule Hexagon.Repo.Migrations.CreateAuthenticationTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:authentication_keys) do
+      add :name, :string, null: false
+      add :token, :binary, null: false, size: 64
+
+      add :user_id, references(:users, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:authentication_keys, [:token])
+  end
+end


### PR DESCRIPTION
This adds basic "Authentication Keys" that act as authorization when using an API client or package manager.

TODO:
- [ ] Permissions and scopes?
- [ ] Show the token better after it's created
- [ ] Delete key functionality
- [ ] Tests